### PR TITLE
Add `MPK Mini` as a valid name and add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ A good way would be to use pip for the dependencies.
 ### Debian-based distributions
 ```
   apt-get install build-essential python3-dev python3-pip libasound2-dev libjack-dev
-  pip3 install python-rtmidi PyQt5
+  pip3 install -r requirements.txt
 ```
 
 ### Mac OS X
 You can install Python and pip using homebrew. You may need a recent version of Mac OS X.
 ```
   brew install python3
-  pip3 install python-rtmidi PyQt5
+  pip3 install -r requirements.txt
 ```
 
 ### Windows
@@ -47,7 +47,7 @@ You can install Python and pip using homebrew. You may need a recent version of 
 * Download and install [Visual C++ build tools 2015](http://landinghub.visualstudio.com/visual-cpp-build-tools)
 * In a command prompt, type:
 ```
-  pip3 install python-rtmidi PyQt5
+  pip3 install -r requirements.txt
 ```
 
 ## Usage

--- a/mpk_m2-editor.py
+++ b/mpk_m2-editor.py
@@ -228,11 +228,11 @@ class Akai_MPK_Mini(Ui_MainWindow):
 
         is_out_open, is_in_open = False, False
         for i, p in enumerate(self.mo.get_ports()):
-            if "MPKmini" in p:
+            if any(mpk in p for mpk in ("MPKmini", "MPK Mini")):
                 self.mo.open_port(i)
                 is_out_open = True
         for i, p in enumerate(self.mi.get_ports()):
-            if "MPKmini" in p:
+            if any(mpk in p for mpk in ("MPKmini", "MPK Mini")):
                 self.mi.open_port(i)
                 self.mi.ignore_types(sysex=False)
                 is_in_open = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-rtmidi
+PyQt5


### PR DESCRIPTION
First of all, thank you for this project!

I added `MPK Mini` as a valid substring, because when I ran the editor it didn't recognise the controller on my system (Linux 5.0.13 kernel). This was the name of the controller:
`MPK Mini Mk II:MPK Mini Mk II MIDI 1 28:0`.

I've also added a `requirements.txt` file for listing the dependencies.